### PR TITLE
[ROS2] 튜토리얼 - publisher, subscriber

### DIFF
--- a/ros2_ws/.gitignore
+++ b/ros2_ws/.gitignore
@@ -1,0 +1,35 @@
+# ROS2 빌드 관련 파일들
+/build/
+install/
+log/
+
+# CMake 관련 파일
+CMakeCache.txt
+CMakeFiles/
+Makefile
+CMakeLists.txt.user
+*.cmake
+
+# VSCode 관련 파일들 (VSCode를 사용하는 경우)
+.vscode/
+
+# IDE 관련 파일들 (예: CLion)
+.idea/
+
+# Python 관련 빌드 파일들
+*.pyc
+*.pyo
+__pycache__
+
+# macOS 관련 파일들
+.DS_Store
+
+# 임시 파일들
+*.swp
+*.bak
+*.tmp
+
+# 패키지에서 자동 생성되는 파일들
+*.egg-info/
+dist/
+build/

--- a/ros2_ws/src/cpp_pubsub/CMakeLists.txt
+++ b/ros2_ws/src/cpp_pubsub/CMakeLists.txt
@@ -12,8 +12,12 @@ find_package(std_msgs REQUIRED)
 add_executable(simple_publisher src/simple_publisher.cpp)
 ament_target_dependencies(simple_publisher rclcpp std_msgs)
 
+add_executable(simple_subscriber src/simple_subscriber.cpp)
+ament_target_dependencies(simple_subscriber rclcpp std_msgs)
+
 install(TARGETS
   simple_publisher
+  simple_subscriber
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/cpp_pubsub/CMakeLists.txt
+++ b/ros2_ws/src/cpp_pubsub/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.8)
+project(cpp_pubsub)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_executable(simple_publisher src/simple_publisher.cpp)
+ament_target_dependencies(simple_publisher rclcpp std_msgs)
+
+install(TARGETS
+  simple_publisher
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros2_ws/src/cpp_pubsub/package.xml
+++ b/ros2_ws/src/cpp_pubsub/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cpp_pubsub</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="mia2583@pusan.ac.kr">myseo</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_ws/src/cpp_pubsub/src/simple_publisher.cpp
+++ b/ros2_ws/src/cpp_pubsub/src/simple_publisher.cpp
@@ -1,0 +1,36 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+class SimplePublisher : public rclcpp::Node {
+public:
+    SimplePublisher() : Node("simple_publisher"), counter_(0) {
+        pub_ = create_publisher<std_msgs::msg::String>("chatter", 10);
+        timer_ = create_wall_timer(1s, std::bind(&SimplePublisher::timerCallback, this));
+
+        RCLCPP_INFO(get_logger(), "publishing at 1 Hz");
+    }
+
+private:
+    unsigned int counter_;
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+    rclcpp::TimerBase::SharedPtr timer_;
+
+    void timerCallback() {
+        auto message = std_msgs::msg::String();
+        message.data = "Hello ROS2 - counter: " + std::to_string(counter_++);
+
+        pub_->publish(message);
+    }
+};
+
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<SimplePublisher>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/ros2_ws/src/cpp_pubsub/src/simple_subscriber.cpp
+++ b/ros2_ws/src/cpp_pubsub/src/simple_subscriber.cpp
@@ -1,0 +1,26 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+using std::placeholders::_1;
+
+class SimpleSubscriber : public rclcpp::Node {
+public:
+    SimpleSubscriber() : Node("simple_subscriber") {
+        sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, std::bind(&SimpleSubscriber::msgCallback, this, _1));
+    }
+
+private:
+    rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+
+    void msgCallback(const std_msgs::msg::String &msg) const {
+        RCLCPP_INFO_STREAM(get_logger(), "I heard: " << msg.data.c_str());
+    }
+};
+
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<SimpleSubscriber>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
## 작업개요
ROS2를 사용한 publisher, subscriber 예제
- 토픽 chatter로 초당 메세지를 publish
- 토픽 chatter를 subscribe

## 실행
```
colcon build      # 빌드
source ./install/setup.bash      # 소싱
ros2 run cpp_pubsub simple_subscriber
# 새로운 터미널 열기
source ./install/setup.bash
ros2 run cpp_pubsub simple_publisher
```

